### PR TITLE
adds url reference

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setup(
     platforms='any',
     install_requires=get_requirements(),
     python_requires='>=3.5',
+    url="https://github.com/Sets88/ssh-crypt",
     entry_points={
         'console_scripts': [
             'ssh-crypt = ssh_crypt:main',


### PR DESCRIPTION
This should add the url key to setup.py.
<img width="266" alt="image" src="https://github.com/Sets88/ssh-crypt/assets/2042971/a7a2a79d-74d6-4542-94f5-8db4f18ab656">
