### PR TITLE
adds master commit workflow

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -1,0 +1,43 @@
+# skips tests on windows
+# todo: adds ruff and mypy checks
+
+name: Master build
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: ["3.8", "3.9", "3.10", "3.11",]
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up Python interpreter [${{ matrix.python-version }}]
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies from tests/requirements.txt
+        shell: bash
+        run: |
+            python -m pip install --upgrade pip
+            pip install setuptools build wheel twine
+            pip install -r requirements.txt
+            pip install pytest
+
+      - name: Runtime checks (pytest)
+        if: ${{ matrix.os != 'windows-latest' }}
+        shell: bash
+        env:
+          PYTHONPATH: .
+        run: |
+          py.test -vvs tests
+


### PR DESCRIPTION
This change will add a workflow action on the master branch: on every commit it will trigger test runs.
An example is [here](https://github.com/cav71/ssh-crypt/actions/runs/5992593654)

I set the minimum python version to 3.8 and test aren't run on windows (at the moment, as I don't have a win machine).