### PR TITLE
Pr/improve agent failure handling

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/psf/black
-  rev: 23.7.0
+  rev: 23.9.0
   hooks:
   - id: black
     exclude: tests

--- a/ssh_crypt/exceptions.py
+++ b/ssh_crypt/exceptions.py
@@ -1,5 +1,11 @@
 class SSHCryptError(Exception):
-    pass
+    def __init__(self, message: str, hint: str = "", **kwargs):
+        # in a cli driver app, on a failure we
+        # would like to display the error message
+        # and a hint (if possible) on how to solve the issue
+        self.message = message
+        self.hint = hint
+        super().__init__(**kwargs)
 
 
 class SSHCrypAgentNotConnected(SSHCryptError):

--- a/ssh_crypt/exceptions.py
+++ b/ssh_crypt/exceptions.py
@@ -1,0 +1,10 @@
+class SSHCryptError(Exception):
+    pass
+
+
+class SSHCrypAgentNotConnected(SSHCryptError):
+    pass
+
+
+class SSHCryptCannotRetrieveKeysError(SSHCryptError):
+    pass

--- a/ssh_crypt/utils.py
+++ b/ssh_crypt/utils.py
@@ -27,7 +27,7 @@ def get_keys():
             "could not get keys from ssh-agent",
             f"check SSH_AUTH_SOCK={os.getenv('SSH_AUTH_SOCK')} "
             f"or SSH_AGENT_PID={os.getenv('SSH_AGENT_PID')} are"
-            f" pointing to the right agent and they are running",
+            f" pointing to the right agent and it is running",
         )
     keys = []
     for i in range(result.get_int()):

--- a/ssh_crypt/utils.py
+++ b/ssh_crypt/utils.py
@@ -1,20 +1,34 @@
+import os
 import binascii
 from typing import Union, Optional
 
 from paramiko import Agent
 from paramiko import AgentKey
-from paramiko.ssh_exception import SSHException
 from paramiko.agent import cSSH2_AGENTC_REQUEST_IDENTITIES, SSH2_AGENT_IDENTITIES_ANSWER
 
 from .ciphers import Decryptor
 from .constants import VALID_SSH_NAME
+from .exceptions import SSHCrypAgentNotConnected, SSHCryptCannotRetrieveKeysError
 
 
 def get_keys():
     agent = Agent()
+
+    # this is the only reliable way to check if there's a connection
+    # (see paramiko.agent.Agent.__init__)
+    if not agent._conn:
+        raise SSHCrypAgentNotConnected(
+            "no connection to an ssh agent",
+            "is ssh-agent running? is SSH_AUTH_SOCK set?",
+        )
     ptype, result = agent._send_message(cSSH2_AGENTC_REQUEST_IDENTITIES)
     if ptype != SSH2_AGENT_IDENTITIES_ANSWER:
-        raise SSHException("could not get keys from ssh-agent")
+        raise SSHCryptCannotRetrieveKeysError(
+            "could not get keys from ssh-agent",
+            f"check SSH_AUTH_SOCK={os.getenv('SSH_AUTH_SOCK')} "
+            f"or SSH_AGENT_PID={os.getenv('SSH_AGENT_PID')} are"
+            f" pointing to the right agent and they are running",
+        )
     keys = []
     for i in range(result.get_int()):
         key_blob = result.get_binary()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,10 +34,9 @@ def ssh_agent(monkeypatch):
         ),
         None,
     )
-    os.environ["SSH_AUTH_SOCK"] = auth_sock
-    os.environ["SSH_AGENT_PID"] = pid
 
-    # make sure we connect to this agent
+    # make sure we connect to this agent, but after the test
+    # is terminated we restore the current state
     monkeypatch.setenv("SSH_AUTH_SOCK", auth_sock)
     monkeypatch.setenv("SSH_AGENT_PID", pid)
     agent = Agent()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,46 @@
+import os
+import subprocess
+import shlex
+import signal
+
+import pytest
+
+
+@pytest.fixture
+def ssh_agent(monkeypatch):
+    from paramiko.agent import Agent
+
+
+    ssh_agent_exec = subprocess.run(
+        ["ssh-agent"], capture_output=True, encoding="utf-8"
+    )
+    pid = next(
+        iter(
+            [
+                s.split("=")[1].strip(";")
+                for s in shlex.split(ssh_agent_exec.stdout)
+                if "SSH_AGENT_PID=" in s
+            ]
+        ),
+        None,
+    )
+    auth_sock = next(
+        iter(
+            [
+                s.split("=")[1].strip(";")
+                for s in shlex.split(ssh_agent_exec.stdout)
+                if "SSH_AUTH_SOCK=" in s
+            ]
+        ),
+        None,
+    )
+    os.environ["SSH_AUTH_SOCK"] = auth_sock
+    os.environ["SSH_AGENT_PID"] = pid
+
+    # make sure we connect to this agent
+    monkeypatch.setenv("SSH_AUTH_SOCK", auth_sock)
+    monkeypatch.setenv("SSH_AGENT_PID", pid)
+    agent = Agent()
+    yield agent
+    os.kill(int(pid), signal.SIGSTOP)
+

--- a/tests/test_encrypt.py
+++ b/tests/test_encrypt.py
@@ -1,16 +1,12 @@
 import pytest
 
-import subprocess
-import shlex
-import os
-import signal
 import types
 import tempfile
 import random
 import string
 import binascii
 
-from paramiko import Agent, AgentKey, Message
+from paramiko import AgentKey, Message
 from paramiko.rsakey import RSAKey
 from paramiko.dsskey import DSSKey
 from paramiko.ecdsakey import ECDSAKey
@@ -24,38 +20,6 @@ from ssh_crypt.utils import get_keys, get_first_key, find_filter_key
 
 SSH2_AGENTC_ADD_IDENTITY = 17
 SSH_AGENT_SUCCESS = 6
-
-
-@pytest.fixture
-def ssh_agent():
-    ssh_agent_exec = subprocess.run(
-        ["ssh-agent"], capture_output=True, encoding="utf-8"
-    )
-    pid = next(
-        iter(
-            [
-                s.split("=")[1].strip(";")
-                for s in shlex.split(ssh_agent_exec.stdout)
-                if "SSH_AGENT_PID=" in s
-            ]
-        ),
-        None,
-    )
-    auth_sock = next(
-        iter(
-            [
-                s.split("=")[1].strip(";")
-                for s in shlex.split(ssh_agent_exec.stdout)
-                if "SSH_AUTH_SOCK=" in s
-            ]
-        ),
-        None,
-    )
-    os.environ["SSH_AUTH_SOCK"] = auth_sock
-    os.environ["SSH_AGENT_PID"] = pid
-    agent = Agent()
-    yield agent
-    os.kill(int(pid), signal.SIGSTOP)
 
 
 def rsa_to_agent(self, ssh_agent, comment="TEST_RSA_KEY"):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,19 @@
+
+import pytest
+
+import ssh_crypt
+from ssh_crypt import exceptions, utils
+
+
+def test_get_keys_missing_agent(monkeypatch):
+    """test failure to connect to an agent"""
+
+    # make sure we don't connect to any ssh agent
+    monkeypatch.delenv("SSH_AUTH_SOCK", raising=False)
+    monkeypatch.delenv("SSH_AGENT_PID", raising=False)
+    pytest.raises(exceptions.SSHCrypAgentNotConnected, ssh_crypt.E, "Hello world")
+    pytest.raises(exceptions.SSHCrypAgentNotConnected, utils.get_keys)
+
+
+def test_get_keys_empty_agent(ssh_agent):
+    assert len(utils.get_keys()) == 0


### PR DESCRIPTION
The reason for making these changes is to start to increase tests coverage and to make this error clearer:
```
SSH_AUTH_SOCK="" python -c "import ssh_crypt; ssh_crypt.E('E')"
...
AttributeError: 'NoneType' object has no attribute 'send'
```

With the changes the message is clearer:
```
SSH_AUTH_SOCK="" python -c "import ssh_crypt; ssh_crypt.E('E')"
...
ssh_crypt.exceptions.SSHCrypAgentNotConnected: ('no connection to an ssh agent', 'is ssh-agent running? is SSH_AUTH_SOCK set?')
```

The complete list of changes:
- pre-commit: update black to the latest version
- consolidate exceptions in a ssh_crypt.exceptions module (easily shared between modules)
- consolidate the ssh_agent fixture into conftest.py module (easily shared between tests)
- created a separate test_utils module to cover ssh_crypt.utils

Testing with:
```
 PYTHONPATH=$(pwd) pytest -vv
```
